### PR TITLE
Reimplement alpha provider identity support

### DIFF
--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -112,6 +112,13 @@ type startCommand struct {
 	EnableExternalSecretStores bool `group:"Alpha Features:" help:"Enable support for External Secret Stores."`
 	EnableUsages               bool `group:"Alpha Features:" help:"Enable support for deletion ordering and resource protection with Usages."`
 	EnableRealtimeCompositions bool `group:"Alpha Features:" help:"Enable support for realtime compositions, i.e. watching composed resources and reconciling compositions immediately when any of the composed resources is updated."`
+	// NOTE(hasheddan): this feature is unlikely to graduate from alpha status
+	// and should be removed when a runtime interface is introduced upstream.
+	// See https://github.com/crossplane/crossplane/issues/2671 for more
+	// information.
+	// TODO(turkenh): Consider removing this feature flag in favor of providing
+	//  a default DeploymentRuntimeConfig.
+	EnableProviderIdentity bool `group:"Alpha Features:" help:"Enable support for Provider identity."`
 
 	EnableCompositionFunctions               bool `group:"Beta Features:" default:"true" help:"Enable support for Composition Functions."`
 	EnableCompositionWebhookSchemaValidation bool `group:"Beta Features:" default:"true" help:"Enable support for Composition validation using schemas."`
@@ -216,6 +223,11 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 		PollInterval:            c.PollInterval,
 		GlobalRateLimiter:       ratelimiter.NewGlobal(c.MaxReconcileRate),
 		Features:                &feature.Flags{},
+	}
+
+	if c.EnableProviderIdentity {
+		o.Features.Enable(features.EnableProviderIdentity)
+		log.Info("Alpha feature enabled", "flag", features.EnableProviderIdentity)
 	}
 
 	if !c.EnableCompositionRevisions {

--- a/go.mod
+++ b/go.mod
@@ -108,7 +108,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.12.10 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.14.10 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.19.0 // indirect
-	github.com/aws/smithy-go v1.13.5 // indirect
+	github.com/aws/smithy-go v1.13.5
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20230510185313-f5e39e5f34c7 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bufbuild/protocompile v0.6.0 // indirect

--- a/internal/controller/pkg/revision/reconciler.go
+++ b/internal/controller/pkg/revision/reconciler.go
@@ -907,6 +907,10 @@ func (r *Reconciler) runtimeManifestBuilderOptions(ctx context.Context, pwr v1.P
 		opts = append(opts, RuntimeManifestBuilderWithRuntimeConfig(rc))
 	}
 
+	if r.features.Enabled(features.EnableProviderIdentity) {
+		opts = append(opts, RuntimeManifestBuilderWithProviderIdentity())
+	}
+
 	// Note(turkenh): Until we completely remove the old controller config
 	// reference, we support both the old and the new way with DeploymentRuntimeConfig.
 	// If both are specified, we will start with DeploymentRuntimeConfig as the

--- a/internal/controller/pkg/revision/runtime.go
+++ b/internal/controller/pkg/revision/runtime.go
@@ -100,6 +100,7 @@ type RuntimeManifestBuilder struct {
 	serviceAccountPullSecrets []corev1.LocalObjectReference
 	runtimeConfig             *v1beta1.DeploymentRuntimeConfig
 	controllerConfig          *v1alpha1.ControllerConfig
+	providerIdentity          bool
 }
 
 // RuntimeManifestBuilderOption is used to configure a RuntimeManifestBuilder.
@@ -126,6 +127,14 @@ func RuntimeManifestBuilderWithControllerConfig(cc *v1alpha1.ControllerConfig) R
 func RuntimeManifestBuilderWithServiceAccountPullSecrets(secrets []corev1.LocalObjectReference) RuntimeManifestBuilderOption {
 	return func(b *RuntimeManifestBuilder) {
 		b.serviceAccountPullSecrets = secrets
+	}
+}
+
+// RuntimeManifestBuilderWithProviderIdentity sets the provider identity flag
+// to use when building the runtime manifests.
+func RuntimeManifestBuilderWithProviderIdentity() RuntimeManifestBuilderOption {
+	return func(b *RuntimeManifestBuilder) {
+		b.providerIdentity = true
 	}
 }
 
@@ -234,6 +243,10 @@ func (b *RuntimeManifestBuilder) Deployment(serviceAccount string, overrides ...
 
 	if b.revision.GetTLSServerSecretName() != nil {
 		allOverrides = append(allOverrides, DeploymentRuntimeWithTLSServerSecret(*b.revision.GetTLSServerSecretName()))
+	}
+
+	if b.providerIdentity {
+		allOverrides = append(allOverrides, DeploymentWithUpboundProviderIdentity())
 	}
 
 	// We append the overrides passed to the function last so that they can

--- a/internal/controller/pkg/revision/uxp_runtime_override_options.go
+++ b/internal/controller/pkg/revision/uxp_runtime_override_options.go
@@ -1,0 +1,32 @@
+package revision
+
+import (
+	"github.com/aws/smithy-go/ptr"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// DeploymentWithUpboundProviderIdentity mounts the Upbound Provider Identity
+// CSI driver as a volume to the runtime container of a Deployment.
+func DeploymentWithUpboundProviderIdentity() DeploymentOverride {
+	proidcVolumeName := "proidc"
+	proidcDriverName := "proidc.csi.upbound.io"
+	proidcMountPath := "/var/run/secrets/upbound.io/provider"
+
+	return func(d *appsv1.Deployment) {
+		d.Spec.Template.Spec.Volumes = append(d.Spec.Template.Spec.Volumes, corev1.Volume{
+			Name: proidcVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				CSI: &corev1.CSIVolumeSource{
+					Driver:   proidcDriverName,
+					ReadOnly: ptr.Bool(true),
+				},
+			},
+		})
+		d.Spec.Template.Spec.Containers[0].VolumeMounts = append(d.Spec.Template.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
+			Name:      proidcVolumeName,
+			ReadOnly:  true,
+			MountPath: proidcMountPath,
+		})
+	}
+}

--- a/internal/controller/pkg/revision/uxp_runtime_test.go
+++ b/internal/controller/pkg/revision/uxp_runtime_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2023 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package revision
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	pkgmetav1 "github.com/crossplane/crossplane/apis/pkg/meta/v1"
+)
+
+func TestUXPRuntimeManifestBuilderDeployment(t *testing.T) {
+	type args struct {
+		builder            ManifestBuilder
+		overrides          []DeploymentOverride
+		serviceAccountName string
+	}
+	type want struct {
+		want *appsv1.Deployment
+	}
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"ProviderDeploymentWithProviderIdentity": {
+			reason: "If provider identity is enabled, a proidc volume should be added.",
+			args: args{
+				builder: &RuntimeManifestBuilder{
+					revision:         providerRevision,
+					namespace:        namespace,
+					providerIdentity: true,
+				},
+				serviceAccountName: providerRevisionName,
+				overrides:          providerDeploymentOverrides(&pkgmetav1.Provider{ObjectMeta: metav1.ObjectMeta{Name: providerMetaName}}, providerRevision),
+			},
+			want: want{
+				want: deploymentProvider(providerName, providerRevisionName, providerImage, DeploymentWithSelectors(map[string]string{
+					"pkg.crossplane.io/provider": providerMetaName,
+					"pkg.crossplane.io/revision": providerRevisionName,
+				}), DeploymentWithUpboundProviderIdentity()),
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := tc.args.builder.Deployment(tc.args.serviceAccountName, tc.args.overrides...)
+			if diff := cmp.Diff(tc.want.want, got); diff != "" {
+				t.Errorf("\n%s\nDeployment(...): -want, +got:\n%s\n", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/internal/features/uxp_features.go
+++ b/internal/features/uxp_features.go
@@ -1,0 +1,10 @@
+package features
+
+import "github.com/crossplane/crossplane-runtime/pkg/feature"
+
+// Alpha Feature flags.
+const (
+	// EnableProviderIdentity enables alpha support for Provider identity. This
+	// feature is only available when running on Upbound.
+	EnableProviderIdentity feature.Flag = "EnableProviderIdentity"
+)


### PR DESCRIPTION
### Description of your changes

Port original PR [upbound#69](https://github.com/upbound/crossplane/pull/69) to refactored new structure of the relevant codebase

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR if necessary.~

### How has this code been tested

Deploy provider-helm with and without the `--enable-provider-identity` flag and ensure the deployment is as expected in both cases.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
